### PR TITLE
fix cache_key timestamp for update

### DIFF
--- a/lib/wpdb_activerecord/post.rb
+++ b/lib/wpdb_activerecord/post.rb
@@ -17,5 +17,11 @@ module WPDB
     has_many :attachments, -> { where(post_type: "attachment") }, foreign_key: "post_parent", class_name: WPDB.configuration.post_class
     has_many :revisions, -> { where(post_type: "revision") }, foreign_key: "post_parent", class_name: WPDB.configuration.post_class
     has_many :postmetas, foreign_key: "post_id", class_name: WPDB.configuration.postmeta_class
+
+    private
+
+    def timestamp_attributes_for_update
+      [:updated_at, :updated_on, :post_modified]
+    end
   end
 end

--- a/lib/wpdb_activerecord/post.rb
+++ b/lib/wpdb_activerecord/post.rb
@@ -20,8 +20,14 @@ module WPDB
 
     private
 
-    def timestamp_attributes_for_update
-      [:updated_at, :updated_on, :post_modified]
+    if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("5.1.0")
+      def self.timestamp_attributes_for_update
+        super << :post_modified
+      end
+    else
+      def timestamp_attributes_for_update
+        super << :post_modified
+      end
     end
   end
 end

--- a/lib/wpdb_activerecord/post.rb
+++ b/lib/wpdb_activerecord/post.rb
@@ -20,9 +20,9 @@ module WPDB
 
     private
 
-    if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("5.1.0")
+    if Rails.gem_version >= Gem::Version.new("5.1.0")
       def self.timestamp_attributes_for_update
-        super << :post_modified
+        super << "post_modified"
       end
     else
       def timestamp_attributes_for_update


### PR DESCRIPTION
In traditional, rails activerecod use [cache_key](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/integration.rb#L64-L89) to produce record's cache key. Use [timestamp_attributes_for_update](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/timestamp.rb#L73-L75) to handle record update.

WPDB database update record use `:post_modified` , but `timestamp_attributes_for_update` only use `updated_at` , `updated_on`

so I overwrite `timestamp_attributes_for_update` for WPDB's `:post_modified`

